### PR TITLE
allow branch names and not just version numbers

### DIFF
--- a/esm_version_checker/__init__.py
+++ b/esm_version_checker/__init__.py
@@ -1,5 +1,5 @@
 """esm_version_checker - Mini package to check versions of diverse esm_tools software"""
 
-__version__ = "4.1.0"
+__version__ = "4.2.0"
 __author__ = "Paul Gierz <pgierz@awi.de>"
 __all__ = []

--- a/esm_version_checker/cli.py
+++ b/esm_version_checker/cli.py
@@ -103,15 +103,22 @@ def pip_upgrade(package, version=None):
                     "-m",
                     "pip",
                     "install",
+                    "--user",
                     "--upgrade",
                     "git+https://github.com/esm-tools/" + package,
                 ]
             )
         except subprocess.CalledProcessError:
-            print("Installation failed. ")
-            print("One reason might be that you provided an invalid version number.")
+            print("Installation failed. Possible reasons are:")
+            print("- You tried to pull a branch that does not exist")
             print(
-                "A list of vaild version numbers is available at https://github.com/esm-tools/"
+                "  A list of vaild branches is available at https://github.com/esm-tools/"
+                + package_name
+                + "/branches"
+            )
+            print("- You provided an invalid version number.")
+            print(
+                "  A list of vaild version numbers is available at https://github.com/esm-tools/"
                 + package_name
                 + "/releases"
             )
@@ -183,10 +190,6 @@ def upgrade(tool_to_upgrade="all"):
                 tool_to_upgrade, version = tool_to_upgrade.split("==")
             else:
                 tool_to_upgrade, version = tool_to_upgrade.split("=")
-            # regex to catch version numbers with format vX.Y.Z e.g. v4.10.2
-            if not re.match(r"v(?:(\d+\.(?:\d+\.)*\d+))", version):
-                print("Ignoring invalid version number ", version)
-                version = None
 
         if esm_tools_installed[tool_to_upgrade]:
             pip_or_pull(tool_to_upgrade, version)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.0
+current_version = 4.2.0
 commit = True
 tag = True
 
@@ -18,3 +18,4 @@ universal = 1
 exclude = docs
 
 [aliases]
+

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="esm_version_checker",
-    version="4.1.0",
+    version="4.2.0",
     url="https://github.com/esm-tools/esm_version_checker",
     license='MIT',
 


### PR DESCRIPTION
allow branch names and not just version numbers
set --user flag for pip (required on blogin), doesn't hurt to have it everywhere else