### PR TITLE
Bugfix for venv

### DIFF
--- a/esm_version_checker/__init__.py
+++ b/esm_version_checker/__init__.py
@@ -1,5 +1,5 @@
 """esm_version_checker - Mini package to check versions of diverse esm_tools software"""
 
-__version__ = "4.3.0"
+__version__ = "4.3.1"
 __author__ = "Paul Gierz <pgierz@awi.de>"
 __all__ = []

--- a/esm_version_checker/cli.py
+++ b/esm_version_checker/cli.py
@@ -97,17 +97,31 @@ def pip_upgrade(package, version=None):
         if version is not None:
             package = package + "@" + version
         try:
-            subprocess.check_call(
-                [
-                    sys.executable,
-                    "-m",
-                    "pip",
-                    "install",
-                    "--user",
-                    "--upgrade",
-                    "git+https://github.com/esm-tools/" + package,
-                ]
-            )
+            # --user causes an error in a venv (which is used e.g. in CI)
+            # explanation: https://github.com/pypa/pip/issues/4141 
+            if bool(os.environ.get("VIRTUAL_ENV")):
+                subprocess.check_call(
+                    [
+                        sys.executable,
+                        "-m",
+                        "pip",
+                        "install",
+                        "--upgrade",
+                        "git+https://github.com/esm-tools/" + package,
+                    ]
+                )
+            else:
+                subprocess.check_call(
+                    [
+                        sys.executable,
+                        "-m",
+                        "pip",
+                        "install",
+                        "--user",
+                        "--upgrade",
+                        "git+https://github.com/esm-tools/" + package,
+                    ]
+                )
         except subprocess.CalledProcessError:
             print("Installation failed. Possible reasons are:")
             print("- You tried to pull a branch that does not exist")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.3.0
+current_version = 4.3.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="esm_version_checker",
-    version="4.3.0",
+    version="4.3.1",
     url="https://github.com/esm-tools/esm_version_checker",
     license='MIT',
 


### PR DESCRIPTION
the `--user` kills CI on blogin as we do a `esm_versions upgrade esm_environment=allow-source-workaround` which does not work in virtualenvs at the moment.