### PR TITLE
New feature: shows the branches if installed in editable mode

### DIFF
--- a/esm_version_checker/cli.py
+++ b/esm_version_checker/cli.py
@@ -52,15 +52,21 @@ def check(args=None):
             import_successful = False
         if import_successful:
             try:
-                print(tool, ":", tool_mod.__version__)
+                message = tool + ": " + tool_mod.__version__
             except AttributeError:
                 try:
-                    print(tool, ":", pkg_resources.get_distribution(tool).version)
-                except:
-                    # print("Oops! %s has no version??" % tool)
+                    message = tool + ": " + pkg_resources.get_distribution(tool).version
+                except AttributeError:
+                    message = f"Opps! {tool} has no version??"
+                except Exception:  # Any other exception:
                     raise
+        if dist_is_editable(tool):
+            repo_path = editable_dist_location(tool)
+            repo = Repo(repo_path)
+            message += f" (development install, on branch: {repo.active_branch.name})"
         else:
-            print(tool, ": unknown version!")
+            message = f"{tool} : unknown version!"
+        print(message)
 
 
 # PG: Blatant theft:
@@ -72,6 +78,15 @@ def dist_is_editable(dist):
         if os.path.isfile(egg_link):
             return True
     return False
+
+
+def editable_dist_location(dist):
+    """Determines where an editable dist is installed"""
+    for path_item in sys.path:
+        egg_link = os.path.join(path_item, dist.replace("_", "-") + ".egg-link")
+        if os.path.isfile(egg_link):
+            return open(egg_link).readlines()[0].strip()
+    return None
 
 
 def pip_install(package):
@@ -98,7 +113,7 @@ def pip_upgrade(package, version=None):
             package = package + "@" + version
         try:
             # --user causes an error in a venv (which is used e.g. in CI)
-            # explanation: https://github.com/pypa/pip/issues/4141 
+            # explanation: https://github.com/pypa/pip/issues/4141
             if bool(os.environ.get("VIRTUAL_ENV")):
                 subprocess.check_call(
                     [


### PR DESCRIPTION
Example:
```
esm_versions check            
You are using the following esm_tools versions:
-----------------------------------------------
esm_archiving : unknown version!
esm_autotests : unknown version!
esm_calendar : unknown version!
esm_database : unknown version!
esm_environment: 4.1.1 (development install, on branch: refac_master_awiesm)
esm_master: 4.1.1 (development install, on branch: refac_master_awiesm)
esm_parser: 4.1.2 (development install, on branch: refac_master_awiesm)
esm_profile : unknown version!
esm_rcfile : unknown version!
esm_runscripts: 4.1.4 (development install, on branch: refac_master_awiesm)
esm_tools: 4.1.5 (development install, on branch: refac_master_awiesm)
esm_plugin_manager: 4.0.1 (development install, on branch: master)
esm_version_checker: 4.3.1 (development install, on branch: feature/show_branches)
```

@seb-wahl: if this looks good to you I'll put it in.