### PR TITLE
Feature/nuke

### DIFF
--- a/esm_version_checker/cli.py
+++ b/esm_version_checker/cli.py
@@ -4,6 +4,7 @@
 import importlib
 import os
 import pkg_resources
+import site
 import subprocess
 import sys
 import re
@@ -39,6 +40,30 @@ def main(args=None):
     # click.echo(help_message)
     return 0
 
+@main.command()
+def nuke(args=None):
+    print("You're pushing the red button. Duck and cover!")
+    print("----------------------------------------------")
+    remove_list = []
+    for package in os.listdir(site.getusersitepackages()):
+        for tool_name in esm_tools_modules:
+            if tool_name in package or tool_name.replace("_", "-") in package:
+                remove_list.append(os.path.join(site.getusersitepackages(), package))
+    print("Will remove the following")
+    print("Python packages:")
+    for package in remove_list:
+        print(f"* {package}")
+    print("Binary programs:")
+    for path_part in os.environ.get("PATH").split(":"):
+        if os.path.exists(path_part):
+            for binary in os.listdir(path_part):
+                if "esm" in binary:
+                    remove_list.append(os.path.join(path_part, binary))
+                    print(f"* {os.path.join(path_part, binary)}")
+    if click.confirm('Do you want to continue?'):
+        for esm_thing in remove_list:
+            print(f"* Removing {esm_thing}")
+            os.remove(esm_thing)
 
 @main.command()
 def check(args=None):

--- a/esm_version_checker/cli.py
+++ b/esm_version_checker/cli.py
@@ -40,6 +40,7 @@ def main(args=None):
     # click.echo(help_message)
     return 0
 
+
 @main.command()
 def nuke(args=None):
     print("You're pushing the red button. Duck and cover!")
@@ -60,10 +61,11 @@ def nuke(args=None):
                 if "esm" in binary:
                     remove_list.append(os.path.join(path_part, binary))
                     print(f"* {os.path.join(path_part, binary)}")
-    if click.confirm('Do you want to continue?'):
+    if click.confirm("Do you want to continue?"):
         for esm_thing in remove_list:
             print(f"* Removing {esm_thing}")
             os.remove(esm_thing)
+
 
 @main.command()
 def check(args=None):


### PR DESCRIPTION
# Summary:

Removes anything related to ESM Tools to give you a fresh start. Note that it also takes out itself...

# Example

```shell
$ esm_versions nuke
You're pushing the red button. Duck and cover!
----------------------------------------------
Will remove the following
Python packages:
* /pf/a/a270077/.local/lib/python3.6/site-packages/esm-version-checker.egg-link
* /pf/a/a270077/.local/lib/python3.6/site-packages/esm_profile-4.0.0.dist-info
* /pf/a/a270077/.local/lib/python3.6/site-packages/esm_rcfile-4.0.0.dist-info
* /pf/a/a270077/.local/lib/python3.6/site-packages/esm_calendar-4.0.1.dist-info
* /pf/a/a270077/.local/lib/python3.6/site-packages/esm-parser.egg-link
* /pf/a/a270077/.local/lib/python3.6/site-packages/esm_rcfile
* /pf/a/a270077/.local/lib/python3.6/site-packages/esm_calendar
* /pf/a/a270077/.local/lib/python3.6/site-packages/esm-tools.egg-link
* /pf/a/a270077/.local/lib/python3.6/site-packages/esm-master.egg-link
* /pf/a/a270077/.local/lib/python3.6/site-packages/esm_database
* /pf/a/a270077/.local/lib/python3.6/site-packages/esm_database-4.0.0.dist-info
* /pf/a/a270077/.local/lib/python3.6/site-packages/esm_profile
Binary programs:
* /pf/a/a270077/.local/bin/esm_master
* /pf/a/a270077/.local/bin/esm_versions
* /pf/a/a270077/.local/bin/esm_database
Do you want to continue? [y/N]: 

```

# Please vote! What should the name of the command be? Nuke, uninstall, killall?

