### PR TITLE
Hotfix/fix version

### DIFF
--- a/esm_version_checker/__init__.py
+++ b/esm_version_checker/__init__.py
@@ -1,6 +1,6 @@
 """esm_version_checker - Mini package to check versions of diverse esm_tools software"""
 
-__version__ = "5.1.1"
+__version__ = "5.1.2"
 __author__ = "Paul Gierz <pgierz@awi.de>"
 __all__ = []
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.1
+current_version = 5.1.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="esm_version_checker",
-    version="5.1.1",
+    version="5.1.2",
     url="https://github.com/esm-tools/esm_version_checker",
     license="MIT",
     author="Paul Gierz",

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "gitpython",
         "PyGithub",
         "tabulate",
+        "packaging",
         "esm_rcfile @ git+https://github.com/esm-tools/esm_rcfile.git",
     ],
     classifiers=[


### PR DESCRIPTION
**TLDR:** it should work now :-)

Apparently there is a problem in `pkg_resources `module in Python. For the modules in non-editable mode, it is fine but in the developer mode. 
`PKG_INFO` file in the egg info is not updated and it is out of synch with the `setup.cfg`. 
Therefore when we `bumpversion` we update the setup.cfg and the __init__.py (indirectly) but `PKG_INFO` still contains the old version.