### PR TITLE
KeyError try/except

### DIFF
--- a/esm_version_checker/__init__.py
+++ b/esm_version_checker/__init__.py
@@ -1,6 +1,6 @@
 """esm_version_checker - Mini package to check versions of diverse esm_tools software"""
 
-__version__ = "5.1.3"
+__version__ = "5.1.4"
 __author__ = "Paul Gierz <pgierz@awi.de>"
 __all__ = []
 

--- a/esm_version_checker/cli.py
+++ b/esm_version_checker/cli.py
@@ -172,7 +172,11 @@ def get_esm_package_attributes(tool):
 
         config = configparser.ConfigParser()
         config.read(os.path.join(file_path, 'setup.cfg'))
-        v2 = config['bumpversion']['current_version'] 
+        try:
+            v2 = config['bumpversion']['current_version'] 
+        except KeyError:
+            # v2 is defined to a default above
+            pass
 
     # Greater version number will be taken
     version = max(version_parse(v1), version_parse(v2))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.3
+current_version = 5.1.4
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="esm_version_checker",
-    version="5.1.3",
+    version="5.1.4",
     url="https://github.com/esm-tools/esm_version_checker",
     license="MIT",
     author="Paul Gierz",


### PR DESCRIPTION
Circumvents the weird bug:

```

Reading:
/mnt/lustre01/pf/a/a270077/conda-envs/mis3/lib/python3.8/site-packages/setup.cfg
Config for esm_runscripts is:
{'DEFAULT': <Section: DEFAULT>}
Traceback (most recent call last):
  File "/pf/a/a270077/conda-envs/mis3/bin/esm_versions", line 8, in <module>
    sys.exit(main())
  File "/pf/a/a270077/conda-envs/mis3/lib/python3.8/site-packages/click/core.py", line 1134, in __call__
    return self.main(*args, **kwargs)
  File "/pf/a/a270077/conda-envs/mis3/lib/python3.8/site-packages/click/core.py", line 1059, in main
    rv = self.invoke(ctx)
  File "/pf/a/a270077/conda-envs/mis3/lib/python3.8/site-packages/click/core.py", line 1665, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/pf/a/a270077/conda-envs/mis3/lib/python3.8/site-packages/click/core.py", line 1401, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/pf/a/a270077/conda-envs/mis3/lib/python3.8/site-packages/click/core.py", line 767, in invoke
    return __callback(*args, **kwargs)
  File "/pf/a/a270077/.local/lib/python3.8/site-packages/esm_version_checker/cli.py", line 266, in check
    attr_dict = get_esm_package_attributes(tool)
  File "/pf/a/a270077/.local/lib/python3.8/site-packages/esm_version_checker/cli.py", line 179, in get_esm_package_attributes
    v2 = config.get('bumpversion', {}).get('current_version')
  File "/pf/a/a270077/conda-envs/mis3/lib/python3.8/configparser.py", line 781, in get
    d = self._unify_values(section, vars)
  File "/pf/a/a270077/conda-envs/mis3/lib/python3.8/configparser.py", line 1149, in _unify_values
    raise NoSectionError(section) from None
configparser.NoSectionError: No section: 'bumpversion'
```
