### PR TITLE
Transitions to monorepo

### DIFF
--- a/esm_version_checker/__init__.py
+++ b/esm_version_checker/__init__.py
@@ -1,6 +1,6 @@
 """esm_version_checker - Mini package to check versions of diverse esm_tools software"""
 
-__version__ = "5.1.5"
+__version__ = "5.1.6"
 __author__ = "Paul Gierz <pgierz@awi.de>"
 __all__ = []
 

--- a/esm_version_checker/cli.py
+++ b/esm_version_checker/cli.py
@@ -21,6 +21,7 @@ import shutil
 import configparser
 from packaging.version import parse as version_parse
 
+from .monorepo import *
 
 class GlobalVars:
     """A struct-like class for holding the global variables. GlobalVars 
@@ -411,10 +412,21 @@ def pip_or_pull(tool, version=None):
             remote = esm_tools_repo.remote()
             remote.pull()
             print("Pulled new version of ", tool)
+
         except AssertionError:
             print("WARNING: Only allowed to pull on release or develop!")
             print("WARNING: You are on a branch: %s" % esm_tools_repo.active_branch.name)
             print("WARNING: Please pull or change branches by yourself!")
+
+        # Get the version of ``esm_tools``
+        distribution = pkg_resources.get_distribution(tool)
+        major_version = int(distribution.version.split(".")[0])
+        # If it is version 6 and ``esm_versions`` is still used, it means that
+        # the special installation of the monorepo is necessary, so here we go...
+        if major_version > 5 or version=="monorepo":
+            if not version:
+                version = major_version
+            install_monorepo(tool, version)
 
     else:
         pip_upgrade(tool, version)

--- a/esm_version_checker/monorepo.py
+++ b/esm_version_checker/monorepo.py
@@ -35,6 +35,7 @@ def install_monorepo(esm_tools, version):
     ]
 
     tools_dir, bin_dir, lib_dirs = find_dir_to_remove(packages)
+    os.chdir(tools_dir)
 
     steps = {
         "uninstall": "Uninstall packages (``pip uninstall esm_<package>``)",
@@ -45,13 +46,6 @@ def install_monorepo(esm_tools, version):
         "rm_easy": ["Remove ESM lines in the ``easy-install.pth`` files:"] + lib_dirs,
         "install": "Install ``ESM-Tools`` again",
     }
-
-    # Dirty fix for installing the monorepo branch for testing previous version 6 is
-    # around. Not used when the monorepo is in release
-    os.chdir(tools_dir)
-    if version=="monorepo":
-         subprocess.check_call(["git", "checkout", "monorepo"])
-         subprocess.check_call(["git", "pull"])
 
     # Printing and questionary
     text = \
@@ -96,8 +90,21 @@ def install_monorepo(esm_tools, version):
             ])
         ).ask()  # returns value of selection
         if "[Quit]" in response:
+            v = "v5.1.24"
+            p = subprocess.check_call(
+                f"git checkout {v}",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                shell=True,
+            )
             sys.exit(1)
         user_confirmed = questionary.confirm("Are you sure?").ask()
+
+    # Dirty fix for installing the monorepo branch for testing previous version 6 is
+    # around. Not used when the monorepo is in release
+    if version=="monorepo":
+         subprocess.check_call(["git", "checkout", "monorepo"])
+         subprocess.check_call(["git", "pull"])
 
     cprint()
 

--- a/esm_version_checker/monorepo.py
+++ b/esm_version_checker/monorepo.py
@@ -158,7 +158,7 @@ def install_monorepo(esm_tools, version):
     c += 1
     cprint(f"**{c}** - {steps['install']}")
     p = subprocess.Popen(
-        f"pip install --user -e {tools_dir}",
+        f"cd {tools_dir} && pip install --user -e .",
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         shell=True,
@@ -167,10 +167,10 @@ def install_monorepo(esm_tools, version):
 
     if "Successfully installed esm-tools" in out:
         cprint(f"**Version {version} installed sucessfully!**")
-        sys.exit(1)
+        sys.exit(0)
     else:
         cprint("--Installation failed!--")
-        sys.exit(0)
+        sys.exit(1)
 
 
 def uninstall(package):

--- a/esm_version_checker/monorepo.py
+++ b/esm_version_checker/monorepo.py
@@ -10,12 +10,13 @@ import sys
 
 import regex as re
 
+
 def install_monorepo(esm_tools, version):
     """
     Does all the magic for successfully installing the monorepo if the user has the
     multirepo already installed.
     """
-    _, columns = os.popen('stty size', 'r').read().split()
+    _, columns = os.popen("stty size", "r").read().split()
     columns = int(columns)
 
     # Packages from multirepo
@@ -48,18 +49,19 @@ def install_monorepo(esm_tools, version):
     }
 
     # Printing and questionary
-    text = \
-        "**Welcome to the monorepository version of ESM-Tools!**\n" \
-        "\n" \
-        f"You are trying to upgrade to the major version ``{version}`` which does " \
-        "not use multiple repositories for different ``esm_<packages>`` anymore, " \
-        "but instead all packages are contained in the ``esm_tools`` package (i.e. " \
-        "esm_runscripts, esm_parser, esm_master, etc). You can find these packages " \
-        "now in ``esm_tools/src/``.\n" \
-        "\n" \
-        "Also note that you won't be able to use ``esm_versions`` command from now " \
-        "on, as this tool is not needed anymore for the monorepository, and it has " \
+    text = (
+        "**Welcome to the monorepository version of ESM-Tools!**\n"
+        "\n"
+        f"You are trying to upgrade to the major version ``{version}`` which does "
+        "not use multiple repositories for different ``esm_<packages>`` anymore, "
+        "but instead all packages are contained in the ``esm_tools`` package (i.e. "
+        "esm_runscripts, esm_parser, esm_master, etc). You can find these packages "
+        "now in ``esm_tools/src/``.\n"
+        "\n"
+        "Also note that you won't be able to use ``esm_versions`` command from now "
+        "on, as this tool is not needed anymore for the monorepository, and it has "
         "been consequently removed."
+    )
 
     cprint()
     cprint("**" + columns * "=" + "**")
@@ -67,8 +69,9 @@ def install_monorepo(esm_tools, version):
     cprint("**" + columns * "=" + "**")
 
     cprint(
-        "The monorepository version needs a special installation. " \
-        "ESM-Tools will perform the next steps:")
+        "The monorepository version needs a special installation. "
+        "ESM-Tools will perform the next steps:"
+    )
 
     c = 1
     for key, value in steps.items():
@@ -83,24 +86,13 @@ def install_monorepo(esm_tools, version):
     user_confirmed = False
     while not user_confirmed:
         response = questionary.select(
-            "Would you like to continue?",
-            choices = ([
-                "Yes!",
-                "[Quit] No, thank you..."
-            ])
+            "Would you like to continue?", choices=(["Yes!", "[Quit] No, thank you..."])
         ).ask()  # returns value of selection
         if "[Quit]" in response:
             # If the user refuses to install the monorepo bring back esm_tools to the
             # last multirepo compatible version.
             v = "v5.1.24"
-            if version=="monorepo":
-                p = subprocess.check_call(
-                    f"git checkout release",
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    shell=True,
-                )
-            else:
+            if not version == "monorepo":
                 p = subprocess.check_call(
                     f"git reset {v}",
                     stdout=subprocess.PIPE,
@@ -112,9 +104,9 @@ def install_monorepo(esm_tools, version):
 
     # Dirty fix for installing the monorepo branch for testing previous version 6 is
     # around. Not used when the monorepo is in release
-    if version=="monorepo":
-         subprocess.check_call(["git", "checkout", "monorepo"])
-         subprocess.check_call(["git", "pull"])
+    if version == "monorepo":
+        subprocess.check_call(["git", "checkout", "monorepo"])
+        subprocess.check_call(["git", "pull"])
 
     cprint()
 
@@ -180,6 +172,7 @@ def install_monorepo(esm_tools, version):
         cprint("--Installation failed!--")
         sys.exit(0)
 
+
 def uninstall(package):
     """
     Taken from https://stackoverflow.com/questions/35080207/how-to-pass-the-same-answer-to-subprocess-popen-automatically
@@ -190,21 +183,21 @@ def uninstall(package):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
     )
-    yes_proc = subprocess.Popen(['yes', 'y'], stdout=process.stdin)
+    yes_proc = subprocess.Popen(["yes", "y"], stdout=process.stdin)
     process_output = process.communicate()[0]
     yes_proc.wait()
 
+
 def find_dir_to_remove(packages):
     path_to_dists = "/".join(site.getusersitepackages().split("/")[:-2])
-    python_dist_libs = [
-        x for x in os.listdir(f"{path_to_dists}/") if "python" in x
-    ]
+    python_dist_libs = [x for x in os.listdir(f"{path_to_dists}/") if "python" in x]
 
     lib_dirs = [f"{path_to_dists}/{x}/site-packages" for x in python_dist_libs]
     bin_dir = "/".join(path_to_dists.split("/")[:-1] + ["bin"])
     tools_dir = pkg_resources.get_distribution("esm_tools").location
 
     return tools_dir, bin_dir, lib_dirs
+
 
 def clean_easy_install(lib_dirs, packages):
     for ld in lib_dirs:
@@ -224,6 +217,7 @@ def clean_easy_install(lib_dirs, packages):
                     else:
                         f.write(line)
                 f.truncate()
+
 
 def cprint(text=""):
     # Bold strings

--- a/esm_version_checker/monorepo.py
+++ b/esm_version_checker/monorepo.py
@@ -91,7 +91,7 @@ def install_monorepo(esm_tools, version):
         if "[Quit]" in response:
             # If the user refuses to install the monorepo bring back esm_tools to the
             # last multirepo compatible version.
-            v = "v5.1.24"
+            v = "v5.1.25"
             if not version == "monorepo":
                 p = subprocess.check_call(
                     f"git reset {v}",

--- a/esm_version_checker/monorepo.py
+++ b/esm_version_checker/monorepo.py
@@ -90,13 +90,23 @@ def install_monorepo(esm_tools, version):
             ])
         ).ask()  # returns value of selection
         if "[Quit]" in response:
+            # If the user refuses to install the monorepo bring back esm_tools to the
+            # last multirepo compatible version.
             v = "v5.1.24"
-            p = subprocess.check_call(
-                f"git checkout {v}",
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                shell=True,
-            )
+            if version=="monorepo":
+                p = subprocess.check_call(
+                    f"git checkout release",
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    shell=True,
+                )
+            else:
+                p = subprocess.check_call(
+                    f"git reset {v}",
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    shell=True,
+                )
             sys.exit(1)
         user_confirmed = questionary.confirm("Are you sure?").ask()
 

--- a/esm_version_checker/monorepo.py
+++ b/esm_version_checker/monorepo.py
@@ -1,0 +1,223 @@
+import colorama
+import glob
+import os
+import pkg_resources
+import questionary
+import shutil
+import site
+import subprocess
+import sys
+
+import regex as re
+
+def install_monorepo(esm_tools, version):
+    """
+    Does all the magic for successfully installing the monorepo if the user has the
+    multirepo already installed.
+    """
+    _, columns = os.popen('stty size', 'r').read().split()
+    columns = int(columns)
+
+    # Packages from multirepo
+    packages = [
+        "esm_calendar",
+        "esm_database",
+        "esm_environment",
+        "esm_master",
+        "esm_motd",
+        "esm_parser",
+        "esm_plugin",
+        "esm_profile",
+        "esm_rcfile",
+        "esm_runscripts",
+        "esm_tools",
+        "esm_version",
+    ]
+
+    tools_dir, bin_dir, lib_dirs = find_dir_to_remove(packages)
+
+    steps = {
+        "uninstall": "Uninstall packages (``pip uninstall esm_<package>``)",
+        "esm_tools": f"Cleanup ``{tools_dir}/esm_tools`` folder",
+        "esm_tools.egg-info": f"Cleanup ``{tools_dir}/esm_tools.egg-info`` folder",
+        "rm_libs": ["Remove esm_<packages> from python libraries in:"] + lib_dirs,
+        "rm_bins": f"Remove esm_<packages> in the bin folder (``rm {bin_dir}/esm_<package>``)",
+        "rm_easy": ["Remove ESM lines in the ``easy-install.pth`` files:"] + lib_dirs,
+        "install": "Install ``ESM-Tools`` again",
+    }
+
+    # Dirty fix for installing the monorepo branch for testing previous version 6 is
+    # around. Not used when the monorepo is in release
+    os.chdir(tools_dir)
+    if version=="monorepo":
+         subprocess.check_call(["git", "checkout", "monorepo"])
+         subprocess.check_call(["git", "pull"])
+
+    # Printing and questionary
+    text = \
+        "**Welcome to the monorepository version of ESM-Tools!**\n" \
+        "\n" \
+        f"You are trying to upgrade to the major version ``{version}`` which does " \
+        "not use multiple repositories for different ``esm_<packages>`` anymore, " \
+        "but instead all packages are contained in the ``esm_tools`` package (i.e. " \
+        "esm_runscripts, esm_parser, esm_master, etc). You can find these packages " \
+        "now in ``esm_tools/src/``.\n" \
+        "\n" \
+        "Also note that you won't be able to use ``esm_versions`` command from now " \
+        "on, as this tool is not needed anymore for the monorepository, and it has " \
+        "been consequently removed."
+
+    cprint()
+    cprint("**" + columns * "=" + "**")
+    cprint(text)
+    cprint("**" + columns * "=" + "**")
+
+    cprint(
+        "The monorepository version needs a special installation. " \
+        "ESM-Tools will perform the next steps:")
+
+    c = 1
+    for key, value in steps.items():
+        if isinstance(value, list):
+            cprint(f"``{c}`` - {value[0]}")
+            for substeps in value[1:]:
+                cprint(f"\t- {substeps}")
+        else:
+            cprint(f"``{c}`` - {value}")
+        c += 1
+
+    user_confirmed = False
+    while not user_confirmed:
+        response = questionary.select(
+            "Would you like to continue?",
+            choices = ([
+                "Yes!",
+                "[Quit] No, thank you..."
+            ])
+        ).ask()  # returns value of selection
+        if "[Quit]" in response:
+            sys.exit(1)
+        user_confirmed = questionary.confirm("Are you sure?").ask()
+
+    cprint()
+
+    # Uninstall packages
+    c = 1
+    cprint(f"**{c}** - {steps['uninstall']}")
+    for package in packages:
+        uninstall(package)
+
+    # Cleanup esm_tools folder
+    clean_folders = ["esm_tools", "esm_tools.egg-info"]
+    for cf in clean_folders:
+        f = f"{tools_dir}/{cf}"
+        if os.path.isdir(f):
+            c += 1
+            cprint(f"**{c}** - {steps[cf]}")
+            shutil.rmtree(f)
+
+    # Remove libs
+    c += 1
+    cprint(f"**{c}** - {steps['rm_libs'][0]}")
+    for lib_dir in lib_dirs:
+        for package in packages:
+            package_files = glob.glob(f"{lib_dir}/{package}*")
+            for f in package_files:
+                cprint(f"\tRemoving ``{f}``")
+                if os.path.isdir(f):
+                    shutil.rmtree(f)
+                else:
+                    os.remove(f)
+
+    # Remove bins
+    c += 1
+    cprint(f"**{c}** - {steps['rm_bins']}")
+    for package in packages:
+        bin_file = glob.glob(f"{bin_dir}/{package}*")
+        if bin_file:
+            bin_file = bin_file[0]
+            if os.path.isfile(bin_file):
+                cprint(f"\tRemoving ``{bin_file}``")
+                subprocess.run(["rm", "-f", bin_file])
+
+    # Clean ``easy-install.pth``
+    c += 1
+    cprint(f"**{c}** - {steps['rm_easy'][0]}")
+    clean_easy_install(lib_dirs, packages)
+
+    # Install the tools
+    c += 1
+    cprint(f"**{c}** - {steps['install']}")
+    p = subprocess.Popen(
+        f"pip install --user -e {tools_dir}",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        shell=True,
+    )
+    out = p.communicate()[0].decode("utf-8")
+
+    if "Successfully installed esm-tools" in out:
+        cprint(f"**Version {version} installed sucessfully!**")
+        sys.exit(1)
+    else:
+        cprint("--Installation failed!--")
+        sys.exit(0)
+
+def uninstall(package):
+    """
+    Taken from https://stackoverflow.com/questions/35080207/how-to-pass-the-same-answer-to-subprocess-popen-automatically
+    """
+    cprint(f"\tUninstalling ``{package}``")
+    process = subprocess.Popen(
+        [sys.executable, "-m", "pip", "uninstall", package],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+    yes_proc = subprocess.Popen(['yes', 'y'], stdout=process.stdin)
+    process_output = process.communicate()[0]
+    yes_proc.wait()
+
+def find_dir_to_remove(packages):
+    path_to_dists = "/".join(site.getusersitepackages().split("/")[:-2])
+    python_dist_libs = [
+        x for x in os.listdir(f"{path_to_dists}/") if "python" in x
+    ]
+
+    lib_dirs = [f"{path_to_dists}/{x}/site-packages" for x in python_dist_libs]
+    bin_dir = "/".join(path_to_dists.split("/")[:-1] + ["bin"])
+    tools_dir = pkg_resources.get_distribution("esm_tools").location
+
+    return tools_dir, bin_dir, lib_dirs
+
+def clean_easy_install(lib_dirs, packages):
+    for ld in lib_dirs:
+        easy_install_file = f"{ld}/easy-install.pth"
+        if os.path.isfile(easy_install_file):
+            cprint(f"\tCleaning ``{easy_install_file}``")
+            with open(easy_install_file, "r+") as f:
+                lines = f.readlines()
+                f.seek(0)
+                for line in lines:
+                    contains_package = False
+                    for package in packages:
+                        if package in line:
+                            contains_package = True
+                    if contains_package:
+                        continue
+                    else:
+                        f.write(line)
+                f.truncate()
+
+def cprint(text=""):
+    # Bold strings
+    bs = "\033[1m"
+    be = "\033[0m"
+    reset_s = colorama.Style.RESET_ALL
+    title_color = colorama.Fore.CYAN
+    error_color = colorama.Fore.RED
+    remarks_color = colorama.Fore.MAGENTA
+
+    text = re.sub("\*\*([^*]*)\*\*", f"{bs}{title_color}\\1{reset_s}{be}", text)
+    text = re.sub("``([^`]*)``", f"{remarks_color}\\1{reset_s}", text)
+    text = re.sub("--([^-]*)--", f"{error_color}\\1{reset_s}", text)
+    print(text)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.5
+current_version = 5.1.6
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="esm_version_checker",
-    version="5.1.5",
+    version="5.1.6",
     url="https://github.com/esm-tools/esm_version_checker",
     license="MIT",
     author="Paul Gierz",


### PR DESCRIPTION
This merge allows for `esm_versions` to be able to install the monorepo version automatically.

Once version 6 is available in `release` the user will only need to do `esm_versions upgrade` to get the installation of monorepo started. Note that this only happens if `esm_tools` is on the `release` branch and the repo is clean.

For testing before version 6 is available you can follow these steps:
1. `esm_tools upgrade` (once this branch is merged)
2. `esm_tools upgrade esm_tools=monorepo`